### PR TITLE
OW Platform upgraded to vertx 3, JDK 8 & Nashorn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin
 target
 \#*#
 *~
+.idea/

--- a/build.gradle
+++ b/build.gradle
@@ -20,25 +20,25 @@ configurations {
 }
 
 repositories {
-  mavenCentral ()
-/*
-  maven { 
-    name "Etherfirma RELEASES"
-    credentials { 
-      username = 'deployer'
-      password = 'squidly'
-    } 
-    url 'http://maven.etherfirma.com:8081/nexus/content/repositories/releases/'
-  }
+    mavenCentral()
 
-  maven { 
-    name "Etherfirma SNAPSHOTS"
-    credentials { 
-      username = 'deployer'
-      password = 'squidly'
-    } 
-    url 'http://maven.etherfirma.com:8081/nexus/content/repositories/snapshots/'
-  }*/
+    maven {
+        name "OpenWager RELEASES"
+        credentials {
+            username = mavenUser
+            password = mavenPassword
+        }
+        url "http://${mavenHost}/nexus/content/repositories/releases/"
+    }
+
+    maven {
+        name "OpenWager SNAPSHOTS"
+        credentials {
+            username = mavenUser
+            password = mavenPassword
+        }
+        url "http://${mavenHost}/nexus/content/repositories/snapshots/"
+    }
 }
 
 uploadArchives { 
@@ -46,11 +46,11 @@ uploadArchives {
     mavenDeployer { 
       configuration = configurations.deployerJars
 
-      snapshotRepository (url: 'http://maven.etherfirma.com:8081/nexus/content/repositories/snapshots') { 
+      snapshotRepository (url: "http://${mavenHost}/nexus/content/repositories/snapshots") { 
         authentication (userName: mavenUser, password: mavenPassword)
       }
  
-      repository (url: 'http://maven.etherfirma.com:8081/nexus/content/repositories/releases/') { 
+      repository (url: "http://${mavenHost}/nexus/content/repositories/releases/") { 
         authentication (userName: mavenUser, password: mavenPassword)
       }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 
 defaultTasks 'clean', 'build'
 
-version = '1.1.0-gradle-SNAPSHOT'
+version = 'ow-1.1.0-SNAPSHOT'
 group = 'com.etherfirma' 
 archivesBaseName = 'efcore'
 description = 'The core Java library'

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
   compile 'javaee:javaee-api:5'
   compile 'org.testng:testng:6.5.2'
   compile 'javax.transaction:jta:1.1'
-  compile group: 'io.vertx', name: 'vertx-core', version: '2.1.6'
+  compile group: 'io.vertx', name: 'vertx-core', version: '3.3.3'
 
 //  testCompile group: 'junit', name: 'junit', version: '4.8.+'
     testCompile 'org.testng:testng:6.0.1'

--- a/src/main/java/com/weaselworks/util/JsonObjectUtil.java
+++ b/src/main/java/com/weaselworks/util/JsonObjectUtil.java
@@ -1,6 +1,6 @@
 package com.weaselworks.util;
 
-import org.vertx.java.core.json.JsonObject;
+import io.vertx.core.json.JsonObject;
 
 /**
  * 
@@ -72,10 +72,10 @@ public class JsonObjectUtil
 		for (int i = 0; i < len; i ++) {
 			final String node = path [i]; 
 			if (i != len - 1) { 
-				o = o.getObject (node); 
+				o = o.getJsonObject (node);
 			} else { 
-				if (o.containsField (node)) { 
-					return (T) o.getField (node); 
+				if (o.containsKey (node)) {
+					return (T) o.getValue (node);
 				} else {  
 					System.out.println ("DEFAULT"); 
 					return  def; 
@@ -90,17 +90,17 @@ public class JsonObjectUtil
 	public static
 	JsonObject merge (final JsonObject a, final JsonObject b)
 	{
-		for (final String field : b.getFieldNames ()) {
-			final Object from = b.getField (field); 
-			if (a.containsField (field)) {
-				final Object to = a.getField (field); 
+		for (final String field : b.fieldNames ()) {
+			final Object from = b.getValue (field);
+			if (a.containsKey (field)) {
+				final Object to = a.getValue (field);
 				if (to instanceof JsonObject && from instanceof JsonObject) { 
 					merge ((JsonObject) to, (JsonObject) from); 
 				} else { 
-					a.putValue (field, from); 
+					a.put (field, from);
 				}
 			} else { 
-				a.putValue (field, from); 
+				a.put (field, from);
 			}
 		}
 		return a; 
@@ -109,7 +109,7 @@ public class JsonObjectUtil
 	/**
 	 * 
 	 * @param json
-	 * @param path
+	 * @param paths
 	 * @param value
 	 */
 	
@@ -119,14 +119,14 @@ public class JsonObjectUtil
 		final int len = paths.length; 
 		for (int i = 0; i < len - 1; i ++) { 
 			final String path = paths [i]; 
-			JsonObject child = json.getObject (path); 
+			JsonObject child = json.getJsonObject (path);
 			if (child == null) { 
 				child = new JsonObject ();
-				json.putObject (path, child); 			
+				json.put (path, child);
 			} 
 			json = child; 
 		}
-		json.putValue (paths [len - 1], value); 
+		json.put (paths [len - 1], value);
 		return; 
 	}
 }	


### PR DESCRIPTION
### What is the problem / feature ?

This library is part of the OW platform upgrade to:
* vertx 3.x
* JDK 8 / Nashorn

It will be required to build OWP

### How did it get fixed / implemented ?

Upgrade vertx artifact from `2.1.6` => `3.3.3`

Then fixed compilation issues due to API changes from vertx 2.x to 3.x:
API changes between vertx 2 and 3 are described in detail in this link:
http://vertx.io/blog/checklist-for-migrating-from-vert-x-2-1-x-to-vert-x-3-part-one/

### How can someone test / see it ?

Install in local maven repo using:

`gradle clean install`